### PR TITLE
MOBILE-1814 Use originalDate in all transaction related screens and not date

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 26
         versionCode 1
-        versionName "1.0.13"
+        versionName "1.0.15"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'
     }

--- a/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaAccountEvent.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaAccountEvent.java
@@ -38,8 +38,12 @@ public class MenigaAccountEvent implements MenigaFeedItem, Parcelable {
 		return messageData;
 	}
 
-	@Override
 	public DateTime getDate() {
+		return date;
+	}
+
+	@Override
+	public DateTime getOriginalDate() {
 		return date;
 	}
 

--- a/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaCustomEvent.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaCustomEvent.java
@@ -36,11 +36,14 @@ public class MenigaCustomEvent implements MenigaFeedItem, Parcelable {
 		return (MenigaFeedItem) super.clone();
 	}
 
-	@Override
 	public DateTime getDate() {
 		return this.date;
 	}
 
+	@Override
+	public DateTime getOriginalDate() {
+		return this.date;
+	}
 
 	@Override
 	public int describeContents() {

--- a/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaEvent.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaEvent.java
@@ -63,6 +63,11 @@ public class MenigaEvent implements MenigaFeedItem, Serializable, Cloneable, Par
 		return this.date;
 	}
 
+	@Override
+	public DateTime getOriginalDate() {
+		return date;
+	}
+
 	public String getBody() {
 		return this.body;
 	}

--- a/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaFeedItem.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaFeedItem.java
@@ -9,5 +9,5 @@ public interface MenigaFeedItem {
 
 	MenigaFeedItem clone() throws CloneNotSupportedException;
 
-	DateTime getDate();
+	DateTime getOriginalDate();
 }

--- a/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaOfferEvent.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaOfferEvent.java
@@ -93,8 +93,12 @@ public class MenigaOfferEvent implements MenigaFeedItem, Serializable, Cloneable
 		return (MenigaOfferEvent) super.clone();
 	}
 
-	@Override
 	public DateTime getDate() {
+		return date;
+	}
+
+	@Override
+	public DateTime getOriginalDate() {
 		return date;
 	}
 

--- a/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaScheduledEvent.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaScheduledEvent.java
@@ -148,6 +148,11 @@ public class MenigaScheduledEvent implements MenigaFeedItem, Serializable, Clone
 		return this.date;
 	}
 
+	@Override
+	public DateTime getOriginalDate() {
+		return date;
+	}
+
 	public String getTopicName() {
 		return this.topicName;
 	}


### PR DESCRIPTION
Refactoring feed items so that originalDate is used exclusively.