### PR TITLE
bug/MOBILE-1956 App freezes and then crashes when user selects Income (other) Cat in New Transactions

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 26
         versionCode 1
-        versionName "1.0.21"
+        versionName "1.0.22"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'
     }

--- a/sdk/src/main/java/com/meniga/sdk/models/categories/MenigaCategory.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/categories/MenigaCategory.java
@@ -319,6 +319,18 @@ public class MenigaCategory extends StateObject implements Parcelable, Serializa
 		dest.writeInt(this.categoryType == null ? -1 : this.categoryType.ordinal());
 		dest.writeString(this.categoryRank);
 		dest.writeValue(this.budgetGenerationType);
+		if (children != null) {
+			MenigaCategory self = null;
+			for (MenigaCategory cat : children) {
+				if (cat.getId() == id) {
+					self = cat;
+					break;
+				}
+			}
+			if (self != null) {
+				children.remove(self);
+			}
+		}
 		dest.writeTypedList(children);
 		dest.writeValue(this.categoryContextId);
 		dest.writeValue(this.orderId);


### PR DESCRIPTION
Fixing an error that can occur when parent is contained in its child list.