### PR TITLE
bug/MOBILE-2070 Planning Target Amount

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 26
         versionCode 1
-        versionName "1.0.27"
+        versionName "1.0.28"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'
     }

--- a/sdk/src/main/java/com/meniga/sdk/models/budget/MenigaBudgetEntry.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/budget/MenigaBudgetEntry.java
@@ -45,7 +45,7 @@ public class MenigaBudgetEntry implements Parcelable, Serializable {
 	}
 
 	public MenigaDecimal getTargetAmount() {
-		return targetAmount;
+		return targetAmount == null ? MenigaDecimal.ZERO : targetAmount;
 	}
 
 	public DateTime getStartDate() {


### PR DESCRIPTION
Avoid returning null from target amount, it causes a lot of extra redundant null checks all over the place.