### PR TITLE
bug/MOBILE-2124-cashback-missing-nfo Older Cashbacks are not showing brandName, reward, rewardType nor title

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 26
         versionCode 1
-        versionName "1.0.29"
+        versionName "1.0.30"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'
     }

--- a/sdk/src/main/java/com/meniga/sdk/models/offers/MenigaOfferPage.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/offers/MenigaOfferPage.java
@@ -47,7 +47,7 @@ public class MenigaOfferPage extends ArrayList<MenigaOffer> implements Serializa
 	@MetaProperty
 	private int totalCount;
 
-	protected MenigaOfferPage() {
+	public MenigaOfferPage() {
 	}
 
 	protected MenigaOfferPage(Parcel in) {
@@ -101,12 +101,16 @@ public class MenigaOfferPage extends ArrayList<MenigaOffer> implements Serializa
 		return expiredWithRedemptionOnly;
 	}
 
-	public boolean isHasMorePages() {
+	public boolean hasMorePages() {
 		return hasMorePages;
 	}
 
 	public int getAvailableOffers() {
 		return availableOffers;
+	}
+
+	public boolean isTermsAndConditionsAccepted() {
+		return termsAndConditionsAccepted;
 	}
 
 	public int getAvailableOffersActivated() {


### PR DESCRIPTION
Must make the offer page's constructor public so that the object won't reset itself when fetching next page.