### PR TITLE
bug/MOBILE-2799 Feed cache

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -19,7 +19,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 1
-        versionName "1.1.40"
+        versionName "1.1.41"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "proguard-rules.pro"
     }

--- a/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaAccountEvent.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/feed/MenigaAccountEvent.java
@@ -18,7 +18,7 @@ public class MenigaAccountEvent implements MenigaFeedItem, Parcelable, Serializa
 	@SerializedName("topicId")
 	protected long accountId;
 	protected String actionText;
-	protected transient MenigaAccountEventData messageData;
+	protected MenigaAccountEventData messageData;
 	protected DateTime date;
 	protected String title;
 	protected String body;
@@ -111,7 +111,7 @@ public class MenigaAccountEvent implements MenigaFeedItem, Parcelable, Serializa
 	@Override
 	public int hashCode() {
 		int result = (int) (id ^ (id >>> 32));
-		result = 31 * result + (int) (accountId ^ (id >>> 32));
+		result = 31 * result + (int) (accountId ^ (accountId >>> 32));
 		result = 31 * result + (actionText != null ? actionText.hashCode() : 0);
 		result = 31 * result + (messageData != null ? messageData.hashCode() : 0);
 		result = 31 * result + (date != null ? date.hashCode() : 0);


### PR DESCRIPTION
Removing the transient keyword from account event message data or else it cant be serialized correctly.