### PR TITLE
improv/SDPOSTE-60 Android SDK categories order by name issue

### DIFF
--- a/sdk/src/main/java/com/meniga/sdk/models/categories/MenigaCategory.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/categories/MenigaCategory.java
@@ -387,12 +387,6 @@ public class MenigaCategory implements Parcelable, Serializable, Cloneable {
 								child.parent = root;
 							}
 						}
-						Collections.sort(root.getChildren(), new Comparator<MenigaCategory>() {
-							@Override
-							public int compare(MenigaCategory lhs, MenigaCategory rhs) {
-								return lhs.getName().compareTo(rhs.getName());
-							}
-						});
 					}
 
 					task.getResult().clear();


### PR DESCRIPTION
Removing the category sorting from fetchRoot. It should be done in front ends and not forced like this in the sdk anyway.