### PR TITLE
improv/MOBILE-3066 Go through all date-time fields and check if they can be used with timezone info or not

### DIFF
--- a/sdk/src/main/java/com/meniga/sdk/MenigaSDK.java
+++ b/sdk/src/main/java/com/meniga/sdk/MenigaSDK.java
@@ -71,7 +71,6 @@ import javax.inject.Inject;
  */
 @SuppressWarnings("WeakerAccess")
 public class MenigaSDK {
-
 	private static PersistenceDelegate persistenceDelegate;
 
 	private static MenigaSettings settings;

--- a/sdk/src/main/java/com/meniga/sdk/webservices/serializers/DateTimeSerializer.java
+++ b/sdk/src/main/java/com/meniga/sdk/webservices/serializers/DateTimeSerializer.java
@@ -9,8 +9,6 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;

--- a/sdk/src/main/java/com/meniga/sdk/webservices/serializers/DateTimeSerializer.java
+++ b/sdk/src/main/java/com/meniga/sdk/webservices/serializers/DateTimeSerializer.java
@@ -21,19 +21,20 @@ import java.lang.reflect.Type;
  * Copyright 2017 Meniga Iceland Inc.
  */
 public class DateTimeSerializer implements JsonDeserializer<DateTime>, JsonSerializer<DateTime> {
-
 	@Override
 	public DateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-		String str = json.getAsString().substring(0, 19);
+		String dateAdString = json.getAsString();
+		if (dateAdString.length() > 19) {
+			dateAdString = dateAdString.substring(0, 19);
+		}
 		DateTimeFormatter format = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss");
 
-		return format.parseDateTime(str);
+		return format.parseDateTime(dateAdString);
 	}
 
 	@Override
 	public JsonElement serialize(DateTime src, Type typeOfSrc, JsonSerializationContext context) {
-		DateTime dateTime = new LocalDateTime(src.getMillis()).toDateTime(DateTimeZone.UTC);
-		DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
-		return new JsonPrimitive(fmt.print(dateTime));
+		DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+		return new JsonPrimitive(formatter.print(src));
 	}
 }


### PR DESCRIPTION
Safely removing the LocalDateTime - everything is already UTC in the app because of line 186 in MenigaSDK - as it should be because the server transforms everything into UTC without preserving the time zone info - a user would create a transaction for the 17th in Australia, but when coming back, would see it under the 16th for example.