### PR TITLE
bug/MOBILE-3507 No orphaned events

### DIFF
--- a/sdk/src/main/java/com/meniga/sdk/converters/TransactionEventSorter.kt
+++ b/sdk/src/main/java/com/meniga/sdk/converters/TransactionEventSorter.kt
@@ -21,15 +21,7 @@ class TransactionEventSorter {
             val topicId = event.topicId;
             val subList = feed.filter { it is MenigaTransaction && it.id == topicId }
 
-            if (subList.isEmpty()) {
-                feed.find { it.date.millis > event.date.millis }.let {
-                    if (it == null) {
-                        feed.add(event)
-                    } else {
-                        feed.add(feed.indexOf(it), event)
-                    }
-                }
-            } else {
+            if (!subList.isEmpty()) {
                 feed.add(feed.indexOf(subList.last()) + 1, event)
                 event.setDate(subList.last().getDate())
             }

--- a/sdk/src/test/java/com/meniga/sdk/converters/TransactionEventSorterTest.java
+++ b/sdk/src/test/java/com/meniga/sdk/converters/TransactionEventSorterTest.java
@@ -70,10 +70,12 @@ public class TransactionEventSorterTest {
 		sorter.moveTransactionEventsToTransaction(feed);
 
 		// Then
-		Assertions.assertThat(feed.get(expectedIndex)).isInstanceOf(MenigaTransactionEvent.class);
-		MenigaTransactionEvent event = (MenigaTransactionEvent) feed.get(expectedIndex);
 		if (verifyDate) {
+			Assertions.assertThat(feed.get(expectedIndex)).isInstanceOf(MenigaTransactionEvent.class);
+			MenigaTransactionEvent event = (MenigaTransactionEvent) feed.get(expectedIndex);
 			verify(event).setDate(eq(expectedDate));
+		} else {
+			Assertions.assertThat(feed.size()).isEqualTo(20);
 		}
 	}
 }


### PR DESCRIPTION
Reverting a part of the transaction event logic. We do not want events in the feed that don't have an associated transaction.