### PR TITLE
Fix offerIds parameter in fetch method

### DIFF
--- a/sdk/src/integrationTest/java/com/meniga/sdk/models/offers/MenigaOffersApiTest.kt
+++ b/sdk/src/integrationTest/java/com/meniga/sdk/models/offers/MenigaOffersApiTest.kt
@@ -48,6 +48,7 @@ object MenigaOffersApiTest : Spek({
                     .hasParameter("skip", "0")
                     .hasParameter("take", "10")
                     .hasParameter("filter.states", "all")
+                    .hasNoParameter("filter.offerIds")
                     .hasParameter("filter.expiredWithRedemptionsOnly", "false")
         }
 

--- a/sdk/src/main/java/com/meniga/sdk/models/offers/MenigaOffer.java
+++ b/sdk/src/main/java/com/meniga/sdk/models/offers/MenigaOffer.java
@@ -437,7 +437,7 @@ public class MenigaOffer implements Parcelable, Serializable {
 	 * @return a page of offers
 	 */
 	public static Result<MenigaOfferPage> fetch(final int skip, final int take) {
-		Result<MenigaOfferPage> task = MenigaOffer.apiOperator.getOffers(skip, take, Collections.singletonList(OfferFilterState.ALL), Collections.singletonList(0L), false);
+		Result<MenigaOfferPage> task = MenigaOffer.apiOperator.getOffers(skip, take, Collections.singletonList(OfferFilterState.ALL), null, false);
 		return MenigaSDK.getMenigaSettings().getTaskAdapter().intercept(task, new Interceptor<MenigaOfferPage>() {
 			@Override
 			public void onFinished(MenigaOfferPage result, boolean failed) {


### PR DESCRIPTION
Previously `fetch` method had a parameter `filter.offerIds = [0L]` and was returning only offers with `id = 0`.